### PR TITLE
Fix typos in the env.py, Update default agent name

### DIFF
--- a/examples/td_agent.py
+++ b/examples/td_agent.py
@@ -24,7 +24,7 @@ from examples.base_agent import BaseAgent
 DEFAULT_VALUE = 0
 EPISODE_CNT = 17000
 BENCH_EPISODE_CNT = 3000
-MODEL_FILE = 'td_agent.dat'
+MODEL_FILE = 'best_td_agent.dat'
 EPSILON = 0.08
 ALPHA = 0.4
 CWD = os.path.dirname(os.path.abspath(__file__))

--- a/gym_tictactoe/env.py
+++ b/gym_tictactoe/env.py
@@ -93,19 +93,18 @@ class TicTacToeEnv(gym.Env):
         self.alpha = alpha
         self.set_start_mark('O')
         self.show_number = show_number
-        self._seed()
-        self._reset()
+        self.reset()
 
     def set_start_mark(self, mark):
         self.start_mark = mark
 
-    def _reset(self):
+    def reset(self):
         self.board = [0] * NUM_LOC
         self.mark = self.start_mark
         self.done = False
         return self._get_obs()
 
-    def _step(self, action):
+    def step(self, action):
         """Step environment by action.
 
         Args:
@@ -142,7 +141,7 @@ class TicTacToeEnv(gym.Env):
     def _get_obs(self):
         return tuple(self.board), self.mark
 
-    def _render(self, mode='human', close=False):
+    def render(self, mode='human', close=False):
         if close:
             return
         if mode == 'human':


### PR DESCRIPTION
Fix typos in env.py like renaming '_reset' to 'reset' which caused errors in agent files in examples.
Update loaded agent name from "td_agent.dat" to "best_td_agent.dat" as the default file stored was named "best_td_agent.dat" according to the --help page.