### PR TITLE
simplify looping logic in base_agent play function

### DIFF
--- a/examples/base_agent.py
+++ b/examples/base_agent.py
@@ -20,35 +20,28 @@ class BaseAgent(object):
 
 
 def play(max_episode=10):
-    episode = 0
     start_mark = 'O'
     env = TicTacToeEnv()
     agents = [BaseAgent('O'),
               BaseAgent('X')]
 
-    while episode < max_episode:
+    for _ in range(max_episode):
         env.set_start_mark(start_mark)
         state = env.reset()
-        _, mark = state
-        done = False
-        while not done:
+        while not env.done:
+            _, mark = state
             env.show_turn(True, mark)
-
+            
             agent = agent_by_mark(agents, mark)
             ava_actions = env.available_actions()
             action = agent.act(state, ava_actions)
             state, reward, done, info = env.step(action)
             env.render()
 
-            if done:
-                env.show_result(True, mark, reward)
-                break
-            else:
-                _, mark = state
+        env.show_result(True, mark, reward)
 
         # rotate start
         start_mark = next_mark(start_mark)
-        episode += 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello! When working with this library, I wrote a play function modeled after what exists in BaseAgent. I made some small tweaks which I think simplify the looping logic, and thought I would open a pull request to share my suggestions. Feel free to adopt or ignore changes!

Basically:

- I check `while not env.done:` instead of `while not done:` which eliminates the need to manually set and update the done variable.
- I rearrange the lines `_, mark = state` and `env.show_result(True, mark, reward)` eliminating the need for the `if done: break` block
- I loop over `max_episode` with a for loop instead of a while loop so you don't have to manually set and increment the `episodes` variable

I realize these changes basically come down to personal preference, but I think they make the code a big shorter, simpler, and therefore easier to grasp.